### PR TITLE
Dispatchpool

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: MyPigSQL
 main: CupidonSauce173\MyPigSQL\MyPigSQL
-version: 1.0.0-beta
+version: 2.0.0-beta
 api: 4.0.0
 description: MySQL Framework to send batches of queries accross multiple database connections in AsyncTasks.

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -2,3 +2,5 @@
 batch-execution-interval: 2
 # will update the batch container in the DispatchBatchThread after x seconds.
 batch-update-interval: 2
+# Set the maximum SQLRequests per batch, will create a new batch and execute it in another DispatchBatchThread on execution.
+request-per-batch: 20

--- a/src/CupidonSauce173/MyPigSQL/Task/DispatchBatchPool.php
+++ b/src/CupidonSauce173/MyPigSQL/Task/DispatchBatchPool.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace CupidonSauce173\MyPigSQL\Task;
+
+use Pool;
+
+class DispatchBatchPool extends Pool
+{
+
+}

--- a/src/CupidonSauce173/MyPigSQL/Task/DispatchBatchThread.php
+++ b/src/CupidonSauce173/MyPigSQL/Task/DispatchBatchThread.php
@@ -65,9 +65,6 @@ class DispatchBatchThread extends Thread
      */
     private function processThread(): void
     {
-        $start = microtime(true);
-        $c = count($this->container['batch'][$this->batch]);
-        var_dump("running thread {$this->getThreadId()} with batch $this->batch: ($c) requests");
         # Categorize queries into connStrings & creating MySQL connections.
         /** @var mysqli[] $connections */
         $connections = [];
@@ -77,7 +74,7 @@ class DispatchBatchThread extends Thread
         /** @var string $query */
         foreach ($this->container['batch'][$this->batch] as $id=>$serialized) {
             /** @var SQLRequest $query */
-            $query = unserialize($serialized);
+            $query = $serialized;
             # Verifying objects integrity.
             if (!$query instanceof SQLRequest) throw new SQLRequestException('Error while processing a SQLRequest');
             $connString = $query->getConnString();
@@ -113,10 +110,6 @@ class DispatchBatchThread extends Thread
                 $stmt->close();
                 unset($queryContainers[$query->getConnString()->getName()][$query->getId()]);
             }
-        }
-        if($this->type == self::HELP_THREAD){
-            $elapsed = microtime(true) - $start;
-            var_dump("Finished to process all queries! Took $elapsed seconds, executed: $c requests");
         }
     }
 

--- a/src/CupidonSauce173/MyPigSQL/Utils/SQLRequest.php
+++ b/src/CupidonSauce173/MyPigSQL/Utils/SQLRequest.php
@@ -10,8 +10,8 @@ class SQLRequest
     private null|string $dataTypes = null;
     private null|array $dataKeys = null;
     private null|SQLConnString $connString = null;
-    private bool $dispatched = false;
-    private bool $completed = false;
+    private bool $dispatched;
+    private bool $completed;
     private string $id;
     private int $batch = 0;
 
@@ -46,6 +46,8 @@ class SQLRequest
         $result->setConnString($connString);
         $result->setCallable($callback);
         $result->setBatch();
+        $result->setDispatched(false);
+        $result->setCompleted(false);
         return $result;
     }
 
@@ -88,31 +90,39 @@ class SQLRequest
     }
 
     /**
-     * Returns if the request has been dispatched to the DispatchBatchThread or to set if the request has been executed.
-     * @param bool $value
+     * Returns if the request has been dispatched to the DispatchBatchThread
      * @return bool
      */
-    public function hasBeenDispatched(bool $value = false): bool
+    public function hasBeenDispatched(): bool
     {
-        if ($value) {
-            $this->dispatched = $value;
-            return $this->dispatched;
-        }
         return $this->dispatched;
     }
 
     /**
-     * Returns if the request has been completed or to set if it has been completed.
+     * To set if the request has been executed.
      * @param bool $value
+     */
+    public function setDispatched(bool $value = true): void
+    {
+        $this->dispatched = $value;
+    }
+
+    /**
+     * Returns if the request has been completed
      * @return bool
      */
-    public function hasBeenCompleted(bool $value = false): bool
+    public function hasBeenCompleted(): bool
     {
-        if($value) {
-            $this->completed = $value;
-            return $this->completed;
-        }
         return $this->completed;
+    }
+
+    /**
+     * To set if it has been completed.
+     * @param bool $value
+     */
+    public function setCompleted(bool $value = true): void
+    {
+        $this->completed = $value;
     }
 
     /**

--- a/src/CupidonSauce173/MyPigSQL/Utils/SQLRequest.php
+++ b/src/CupidonSauce173/MyPigSQL/Utils/SQLRequest.php
@@ -10,8 +10,10 @@ class SQLRequest
     private null|string $dataTypes = null;
     private null|array $dataKeys = null;
     private null|SQLConnString $connString = null;
-    private bool $validated = false;
+    private bool $dispatched = false;
+    private bool $completed = false;
     private string $id;
+    private int $batch = 0;
 
     /** @var null|callable $callable */
     private $callable = null;
@@ -28,10 +30,11 @@ class SQLRequest
      * @param array $dataKeys
      * @param SQLConnString $connString
      * @param null|callable $callback
+     * @param int $batch
      * @return SQLRequest
      * @throws SQLRequestException
      */
-    public static function create(string $query, string $dataTypes, array $dataKeys, SQLConnString $connString, null|callable $callback = null): self
+    public static function create(string $query, string $dataTypes, array $dataKeys, SQLConnString $connString, null|callable $callback = null, int $batch = 0): self
     {
         $result = new self();
         if (empty($query)) {
@@ -42,7 +45,26 @@ class SQLRequest
         $result->setDataKeys($dataKeys);
         $result->setConnString($connString);
         $result->setCallable($callback);
+        $result->setBatch();
         return $result;
+    }
+
+    /**
+     * To set in which batch this request will be executed.
+     * @param int $batchNumber
+     */
+    public function setBatch(int $batchNumber = 0): void
+    {
+        $this->batch = $batchNumber;
+    }
+
+    /**
+     * Returns in which batch this request will be executed.
+     * @return int
+     */
+    public function getBatch(): int
+    {
+        return $this->batch;
     }
 
     /**
@@ -66,17 +88,31 @@ class SQLRequest
     }
 
     /**
-     * Returns if the request has been executed or to set if the request has been executed.
+     * Returns if the request has been dispatched to the DispatchBatchThread or to set if the request has been executed.
      * @param bool $value
      * @return bool
      */
-    public function hasBeenExecuted(bool $value = false): bool
+    public function hasBeenDispatched(bool $value = false): bool
     {
         if ($value) {
-            $this->validated = $value;
-            return $this->validated;
+            $this->dispatched = $value;
+            return $this->dispatched;
         }
-        return $this->validated;
+        return $this->dispatched;
+    }
+
+    /**
+     * Returns if the request has been completed or to set if it has been completed.
+     * @param bool $value
+     * @return bool
+     */
+    public function hasBeenCompleted(bool $value = false): bool
+    {
+        if($value) {
+            $this->completed = $value;
+            return $this->completed;
+        }
+        return $this->completed;
     }
 
     /**


### PR DESCRIPTION
### Major changes
- New `DispatchBatchPool ` class.
- Now, the user can set a maximum requests per batch (20 recommended). When exceeded, the requests will jump to a second batch that will be executed on another thread.
- New DispatchBatchThread types (`HELP_THREAD` & `MAIN_THREAD`).

### SQLRequest methods changes
- `SQLRequest::isExecuted()` has been renamed `SQLRequest::hasBeenDispatched()`.
- Added `SQLRequest::setDispatched($value)`.
- Added `SQLRequest::hasBeenCompleted()`.
- Added `SQLRequest::setCompleted($value)`.

### API Changes
- `MyPigSQL::removeQueryFromBatch($id)` has been changed to `MyPigSQL::removeQueryFromBatch($id, $batch`.

### DispatchBatchPool
This class extends `Pool` and has, for now, no methods. But the end goal will be to let users create their own batches of requests and send them over a custom `DispatchBatchPool ` where they will be able to set a batch, the amount of `DispatchBatchThread` they want in them and other few options. The batch will be divided by the amount of `DispatchBathThread` the user set.

## More...

### Config.yml
- Now, you can set the `request-per-batch` which will limit the amount of `SQLRequests` in a single batch. **`20`** is the default value and should be kept that way. If your `batch-update-interval` is set to 2 seconds, it means that in order to create a new batch, you would need to have more **more than 20 `SQLRequests` per 2 seconds**.

### Current  Bugs
- There are `zombie SQLRequest` that can stay in the batches but they won't be executed multiple times and are extremely rare.
- The repeating `ClosureTask` task taking care of firing up the `DispatchBatchThreads` and preparing the requests isn't optimized and can overload the main thread if there are too many requests. This has been observed when creating a request every 1-3 ticks.
- For some reason, `SQLRequest::setDispatched()` & `SQLRequest::setCompleted()` will not set the value to `true` if the developer passes no variable to them (they are using `bool $value = true` when passing no variable to them. 

### Next for 3.0.0-beta
- Optimization of the preparation of the ``SQLRequests` in the ClosureTask.
- Addition of the missing methods from the `DispatchBatchPool`.
- `SQLRequest` priority system where certain requests will wait for x request to be completed before being dispatched.
- Adding method `SQLRequest::waitFor(string $id)`.